### PR TITLE
Remove native GUI from Trustly iFrame

### DIFF
--- a/src/main/java/com/hedvig/botService/web/TriggerController.java
+++ b/src/main/java/com/hedvig/botService/web/TriggerController.java
@@ -55,7 +55,7 @@ public class TriggerController {
     }
 
     TriggerResponseDTO response =
-        new TriggerResponseDTO(triggerUrl + "&gui=native&color=%23651EFF&bordercolor=%230F007A");
+        new TriggerResponseDTO(triggerUrl);
     return ResponseEntity.ok(response);
   }
 

--- a/src/test/java/com/hedvig/botService/web/TriggerControllerTest.java
+++ b/src/test/java/com/hedvig/botService/web/TriggerControllerTest.java
@@ -74,7 +74,7 @@ public class TriggerControllerTest {
         .andExpect(status().is2xxSuccessful())
         .andExpect(
             jsonPath("$.url")
-                .value(triggerURL + "&gui=native&color=%23651EFF&bordercolor=%230F007A"))
+                .value(triggerURL))
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8));
   }
 


### PR DESCRIPTION
Trustly has deprecated their Native GUI for the iFrame and are promising a better look for the new one.
Lets take a look and see if this is acceptable.