### PR TITLE
add messages from back-office to the messageList to avoid errors when their lookup fails

### DIFF
--- a/src/main/java/com/hedvig/botService/chat/Conversation.kt
+++ b/src/main/java/com/hedvig/botService/chat/Conversation.kt
@@ -54,6 +54,10 @@ abstract class Conversation(
     return m
   }
 
+  fun addMessage(message: Message) {
+    messageList[message.id] = message
+  }
+
   protected fun addRelayToChatMessage(s1: String, s2: String) {
     val i = findLastChatMessageId(s1)
 
@@ -323,7 +327,7 @@ abstract class Conversation(
     msg.header.messageId = null
     msg.body.id = null
     msg.id = id
-
+    addMessage(msg)
     return msg
   }
 

--- a/src/main/java/com/hedvig/botService/chat/FreeChatConversation.java
+++ b/src/main/java/com/hedvig/botService/chat/FreeChatConversation.java
@@ -60,7 +60,6 @@ public class FreeChatConversation extends Conversation {
       FREE_CHAT_FROM_CLAIM,
       MessageHeader.createRichTextHeader(),
       new MessageBodyText("Självklart, vad kan jag hjälpa dig med?"));
-
   }
 
   @Override
@@ -114,7 +113,7 @@ public class FreeChatConversation extends Conversation {
     msg.globalId = null;
     msg.body.id = null;
     msg.id = FREE_CHAT_FROM_BO;
-
+    addMessage(msg);
     return msg;
   }
 

--- a/src/test/java/com/hedvig/botService/services/SessionManagerTest.java
+++ b/src/test/java/com/hedvig/botService/services/SessionManagerTest.java
@@ -36,8 +36,7 @@ import static com.hedvig.botService.enteties.message.MessageHeader.HEDVIG_USER_I
 import static com.hedvig.botService.services.TriggerServiceTest.TOLVANSSON_MEMBERID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SessionManagerTest {
@@ -103,6 +102,7 @@ public class SessionManagerTest {
         .thenReturn(Lists.newArrayList(SELECT_LINK));
     when(mockConversation.getUserContext())
         .thenReturn(tolvanssonUserContext);
+    doNothing().when(mockConversation).addMessage(any());
 
     AddMessageRequestDTO requestDTO = new AddMessageRequestDTO(TOLVANSSON_MEMBERID, MESSAGE, false);
 


### PR DESCRIPTION
## What
- Make sure `createBackOfficeMessage` adds messages to the `messageList` of the conversation

## Why
- We constantly get errors about one string specifically that doesn't seem to be in the `Conversation`
- Log statement: https://app.datadoghq.eu/logs?query=status%3Aerror%20service%3Abot-service&event=AQAAAXqZ3x_Hm8iMmQAAAABBWHFaM3hfekFBRHJpYjJvdl9jOHBBQUE&index=%2A

## Screenshot
![image](https://user-images.githubusercontent.com/2649932/125260251-71949480-e300-11eb-8c2a-1491104425a6.png)

